### PR TITLE
One profile

### DIFF
--- a/Modules/rpnphy/6.1.0/src/surface/ebudget_svs2_oneprofile_skin.F90
+++ b/Modules/rpnphy/6.1.0/src/surface/ebudget_svs2_oneprofile_skin.F90
@@ -627,7 +627,6 @@
                  ZDH = VGHEIGHT(I)*ZRCHD
                  VIT(I)   = VMOD(I)
                  ZUSTAR = VMOD(I) * KARMAN / LOG((ZU4FLX(I)-ZDH)/Z0M4FLX(I)) ! ustar above the canopy used in the aero resistances for turbulent fluxes
-
                  ZFSURF = 1. + ZRALAI * (1. - EXP(-CLUMPING * LAIVH(I) * VGH_DENS(I))) 
                  ZRSURF(I) = LOG(Z0M4FLX(I) / Z0HG(I)) / (ZUSTAR * KARMAN) * ZFSURF ! The heat roughness length should be the one at the surface below canopy 
               ELSE
@@ -637,7 +636,6 @@
                  Z0M4FLX(I) = Z0TEMP(I)
                  Z0H4FLX(I) = Z0HG(I)
                  VIT(I)   = VMOD(I)
-                 ZUSTAR = VMOD(I) * KARMAN / LOG(ZU4FLX(I)/Z0M4FLX(I)) ! ustar above the canopy used in the aero resistances for turbulent fluxes
                  ZRSURF(I) = 0.
               ENDIF
 

--- a/Modules/rpnphy/6.1.0/src/surface/svs2.F90
+++ b/Modules/rpnphy/6.1.0/src/surface/svs2.F90
@@ -630,7 +630,7 @@ subroutine svs2(BUS, BUSSIZ, PTSURF, PTSURFSIZ, DT, KOUNT, TRNCH, N, M, NK)
                   bus(x(TPSOIL    ,1,1)) ,    & 
                   bus(x(TPERM     ,1,1)) , bus(x(GFLUXSA,1,1)), bus(x(GFLUXSV,1,1)), &  
                   DT                     , VMOD, VDIR, bus(x(DLAT,1,1)),     &   
-                  zfsolis ,ALVA ,bus(x(laiva,1,1)),GAMVA , BUS(x(ALVL,1,1)), & 
+                  zfsolis ,ALVA ,bus(x(laiva,1,1)),BUS(x(LAIVH  ,1,1)),GAMVA , BUS(x(ALVL,1,1)), & 
                   BUS(x(ALVH,1,1)), BUS(x(ALGR,1,1)), BUS(x(EMISGR,1,1)),    & 
                   bus(x(FDSI       ,1,1)) , zthetaa ,    &   
                   bus(x(FCOR       ,1,1)) , bus(x(zusl,1,1)),    &  
@@ -678,7 +678,6 @@ subroutine svs2(BUS, BUSSIZ, PTSURF, PTSURFSIZ, DT, KOUNT, TRNCH, N, M, NK)
                   bus(x(ilmo  ,1,indx_soil)), bus(x(hst  ,1,indx_soil)), &   
                   TRAD, N,   &
                   bus(x(QVEG ,1,1)), bus(x(QGV   ,1,1)), bus(x(QGR   ,1,1)), & 
-                  bus(x(TAF   ,1,1)), bus(x(QAF   ,1,1)), bus(x(VAF   ,1,1)), & 
                   RPP, bus(x(Z0HA ,1,1)), CLUMPING, bus(x(VGH_DENS,1,1)), BUS(x(Z0MVH  ,1,1)))
 
 !             CALL EBUDGET_SVS2_ONEPROFILE(bus(x(TSA ,1,1)),  &  
@@ -735,7 +734,7 @@ subroutine svs2(BUS, BUSSIZ, PTSURF, PTSURFSIZ, DT, KOUNT, TRNCH, N, M, NK)
 !                  TRAD, N,   &
 !                  bus(x(QVEG ,1,1)), bus(x(QGV   ,1,1)), bus(x(QGR   ,1,1)), & 
 !                  bus(x(TAF   ,1,1)), bus(x(QAF   ,1,1)), bus(x(VAF   ,1,1)), & 
-!                  RPP, bus(x(Z0HA ,1,1)), CLUMPING, bus(x(VGH_DENS,1,1)), BUS(x(Z0MVH  ,1,1)))
+!                  RPP, bus(x(Z0HA ,1,1)))
 
         ! Update vegetation temperature with low vegetation. 
         ! VV TO BE MODIFIED: Intermediate step during developement. 

--- a/test_case/MESH_parameters_cdp_svs2.txt
+++ b/test_case/MESH_parameters_cdp_svs2.txt
@@ -44,7 +44,7 @@ tpsoilv        280.0   280.0   280.0 ! soil temperature below high veg  (K) (not
 tperm      280.0 ! (Deep soil temperature)
 
 !> Activate single soil column in SVS2
-lunique_profile_svs2 .false.
+lunique_profile_svs2 .true.
 
 !> lower boundary condition for heat diffusion in SVS2: TPERM or 0FLUX
 lbcheat_svs2 TPERM
@@ -82,10 +82,10 @@ lout_snow_profile  .true.  ! Create output file containing detailed information 
 nprofile_day     4          ! Number of snow profiles per day (can be  1, 2, 4, 6, 12, 24)
 lout_snow_enbal  .false.    ! Create output file containing information about the snowpack energy and mass budget
 
-!> Physical constant for snowpack scheme (uncomment to use)
-!>xvaging_noglacier  60 ! Aging coefficient (in days) used for albedo calculation in visible range (see modd_snow_par)
-
 ! Activate canopy module
-lsnow_interception_svs2  LCANO
+lsnow_interception_svs2  .true.
 lcan_ref_level_above .true.
 lsnow_canopy_mod .true.
+
+!> Physical constant for snowpack scheme (uncomment to use)
+!>xvaging_noglacier  60 ! Aging coefficient (in days) used for albedo calculation in visible range (see modd_snow_par)


### PR DESCRIPTION
- RSURF was added to calculate the total resistance in the computation of the turbulent fluxes for soil under high vegetation if lcan_ref_level_above = .true. (forcing above canopy. A stability correction is accounted for.
- if lcan_ref_level_above = .true., the heights for the computation of the turbulent fluxes are ZUSL(I) + VGHEIGHT(I) and ZTSL(I) + VGHEIGHT(I)
- the variables TAF, QAF, and VAF representing the forcing within the Canopy using Deardoff were removed and replaced by the forcing above or below the canopy depending on lcan_ref_level_above 
- Logistic variables added to the MESH_parameters of the test_case for svs2.
