### PR TITLE
add options to specify lmin

### DIFF
--- a/Driver/MESH_Driver/read_parameters_csv.f90
+++ b/Driver/MESH_Driver/read_parameters_csv.f90
@@ -426,6 +426,35 @@ subroutine read_parameters_csv(shd, iun, fname, ierr)
                     call assign_line_args(svs_mesh%vs%hveglpol, p, args(2:), istat)
                 end if
 
+
+
+            case (VN_SVS_LMIN_STABLE)
+                if (.not. svs_mesh%PROCESS_ACTIVE ) then
+
+                    istat = istat + radix(istat)**pstat%INACTIVE
+                else
+                    p = 1
+                    call assign_line_args(svs_mesh%vs%lmin_stable, args(2), istat)
+                end if
+
+            case (VN_SVS_LMO_WINTER)
+                if (.not. svs_mesh%PROCESS_ACTIVE) then
+
+                    istat = istat + radix(istat)**pstat%INACTIVE
+                else
+                    p = 1
+                    call assign_line_args(svs_mesh%vs%lmo_winter, args(2), istat)
+                end if
+
+
+            case (VN_SVS_LVAR_LMIN_STABLE)
+                if (.not. svs_mesh%PROCESS_ACTIVE  ) then
+                    istat = istat + radix(istat)**pstat%INACTIVE
+                else
+                    p = 1
+                    call assign_line_args(svs_mesh%vs%lvar_lmin_stable, args(2), istat)
+                end if
+
             case (VN_SVS_LOUT_SVS1_WATBAL)
                 if (.not. svs_mesh%PROCESS_ACTIVE .or. svs_mesh%vs%schmsol=='SVS2' ) then
                     istat = istat + radix(istat)**pstat%INACTIVE

--- a/LSS_Model/SVS/svs1/src/runsvs_mesh.F90
+++ b/LSS_Model/SVS/svs1/src/runsvs_mesh.F90
@@ -149,9 +149,9 @@ module runsvs_mesh
     character(len = *), parameter, public :: VN_SVS_HVEGLPOL = 'HVEGLPOL' ! For svs2 only
     character(len = *), parameter, public :: VN_SVS_LWRITE_RESTART = 'LWRITE_RESTART' ! For svs2 only 
     character(len = *), parameter, public :: VN_SVS_LREAD_RESTART = 'LREAD_RESTART' ! For svs2 only 
-    character(len = *), parameter, public :: VN_SVS_LVAR_LMIN_STABLE = 'LVAR_LMIN_STABLE ' ! Should be used for svs2 only 
-    character(len = *), parameter, public :: VN_SVS_LMO_WINTER = 'LMO_WINTER' ! Should be used for SVS1 = -1
-    character(len = *), parameter, public :: VN_SVS_LMIN_STABLE = 'LMIN_STABLE' ! Is used for SVS2 if LVAR_LMIN_STABLE == .true.
+    character(len = *), parameter, public :: VN_SVS_LVAR_LMIN_STABLE = 'LVAR_LMIN_STABLE '
+    character(len = *), parameter, public :: VN_SVS_LMO_WINTER = 'LMO_WINTER'  ! Used if LVAR_LMIN_STABLE == 'VAR'
+    character(len = *), parameter, public :: VN_SVS_LMIN_STABLE = 'LMIN_STABLE' ! Used if LVAR_LMIN_STABLE == 'CST'
 
     !> SVS variables names for I/O (modifiers/special conditions).
     character(len = *), parameter, public :: VN_SVS_SAND_N = 'SAND_N'
@@ -2104,12 +2104,12 @@ ierr = 200
         !> Increment 'kount'.
         kount = kount + 1
 
-        !> Update 'lmin' if active (greater than zero).
-        if (lvar_lmin_stable .EQ. 'CST') then ! Use new value of 20 m for lmin_soil to avoid underestimation of turbulent fluxes under very stable atm 
+        if (lvar_lmin_stable .EQ. 'CST') then ! Use constant lmin = lmin_stable 
             sl_lmin_soil = svs_mesh%vs%lmin_stable
         else if (LVAR_LMIN_STABLE .EQ. 'NON') then
             sl_lmin_soil = -1.
         else
+        !> Update 'lmin' if active (greater than zero).
             if (svs_mesh%vs%lmo_winter > 0.0) then
                 if (ic%now%jday < 210) then
 

--- a/Modules/rpnphy/6.1.0/src/surface/sfc_nml.F90
+++ b/Modules/rpnphy/6.1.0/src/surface/sfc_nml.F90
@@ -362,6 +362,13 @@ contains
             return
          endif
 
+         if (.not.any(lvar_lmin_stable == LVAR_LMIN_STABLE_OPT)) then
+            call str_concat(msg_S, LVAR_LMIN_STABLE_OPT, ', ')
+            call msg(MSG_ERROR, '(sfc_nml_check) lvar_lmin_stable = '//trim(lvar_lmin_stable)//&
+                 ' : Should be one of: '//trim(msg_S))
+            return
+         endif
+
          if (.not.any(vf_type == VFTYPE_OPT)) then
             call str_concat(msg_S, VFTYPE_OPT,', ')
             call msg(MSG_ERROR,'(sfc_nml_check) vf_type = '//trim(vf_type)//' : Should be one of: '//trim(msg_S))

--- a/Modules/rpnphy/6.1.0/src/surface/sfc_options.F90
+++ b/Modules/rpnphy/6.1.0/src/surface/sfc_options.F90
@@ -406,7 +406,7 @@ module sfc_options
    !# Options for minimum length of MO
    !# * 'NON'   :  lmo_winter is fixed to -1 and a minimum wind speed is imposed
    !# * 'CST'   :  a minimum constant length of MO is specified by the used (lmin_stable)
-   !# * 'VAR'   :  a minimum length of MO in the winter is specified by the used (lmo_winter)
+   !# * 'VAR'   :  a variable length of MO is used as a function of the season. It ranges between the value lmo_winter in wintertime (value provided by the user) and 1 in summer.
    character(len=3) :: lvar_lmin_stable    = 'NON'
    namelist /surface_cfgs/ lvar_lmin_stable 
    character(len=*), parameter :: LVAR_LMIN_STABLE_OPT(3) = (/ &

--- a/Modules/rpnphy/6.1.0/src/surface/sfc_options.F90
+++ b/Modules/rpnphy/6.1.0/src/surface/sfc_options.F90
@@ -403,6 +403,19 @@ module sfc_options
    logical           :: lcano_svs2 = .true.
    namelist /surface_cfgs/ lcano_svs2
 
+   !# Options for minimum length of MO
+   !# * 'NON'   :  lmo_winter is fixed to -1 and a minimum wind speed is imposed
+   !# * 'CST'   :  a minimum constant length of MO is specified by the used (lmin_stable)
+   !# * 'VAR'   :  a minimum length of MO in the winter is specified by the used (lmo_winter)
+   character(len=3) :: lvar_lmin_stable    = 'NON'
+   namelist /surface_cfgs/ lvar_lmin_stable 
+   character(len=*), parameter :: LVAR_LMIN_STABLE_OPT(3) = (/ &
+        'NON',  &
+        'CST',  &
+        'VAR'   &
+        /)
+
+
    !# Emissivity for water
    !# * '_constant_' : A fixed floating point value used as a constant
    character(len=16) :: water_emiss = '1.'

--- a/test_case/MESH_parameters_cdp_svs1.txt
+++ b/test_case/MESH_parameters_cdp_svs1.txt
@@ -84,3 +84,8 @@ wsnow            0.0 !kg m**-2
 
 !> Output
 lout_svs1_watbal .true. ! Add water balance output for SVS1.
+
+! Specify how to manage the minimum MO length under stable conditions (CST, VAR, NON)
+lvar_lmin_stable NON
+! lmin_stable 20.  ! Only used if lvar_lmin_stable = CST
+! lmo_winter -1. ! Only used if lvar_lmin_stable = VAR

--- a/test_case/MESH_parameters_cdp_svs2.txt
+++ b/test_case/MESH_parameters_cdp_svs2.txt
@@ -121,6 +121,10 @@ VGH_DENS    0.
 lwrite_restart .true.      ! Option to write a restart file for SVS2 at the end of the simulation
 lread_restart  .false.      ! Option to read restart information for SVS2/Crocus in MESH_paramater.txt.        
 
+! Specify how to manage the minimum MO length under stable conditions (CST, VAR, NON)
+lvar_lmin_stable CST
+lmin_stable 20.  ! Only used if lvar_lmin_stable = CST
+! lmo_winter -1. ! Only used if lvar_lmin_stable = VAR
 
 !> Physical constant for snowpack scheme (uncomment to use)
 !>xvaging_noglacier  60 ! Aging coefficient (in days) used for albedo calculation in visible range (see modd_snow_par)


### PR DESCRIPTION
A new key was added to the MESH_parameters LVAR_LMIN_STABLE that can be 'CST'/'VAR'/'NON'
If LVAR_LMIN_STABLE = 'CST', the user should specify the variable 'lmin_stable' in the MESH_parameters and that value will be used for sl_Lmin_soil which will be constant in the simulation
If LVAR_LMIN_STABLE = 'VAR', the user should specify the variable 'lmo_winter' in the MESH_parameters and that value will be used to calculate a varying lmin over the winter with the value lmo_winter being the minimum value.
If LVAR_LMIN_STABLE = 'NON', the user does not have to specify another variable and sl_Lmin_soil = -1, i.e. a minimum wind speed is used.