### PR TITLE
Added changes for 'Other' fixing compilation using GNU/gfortran

### DIFF
--- a/LSS_Model/SVS/runsvs_mesh.F90
+++ b/LSS_Model/SVS/runsvs_mesh.F90
@@ -508,6 +508,17 @@ module runsvs_mesh
    lcsun   = (stcond == 'CONSUN')
    lmp     = (stcond(1:3) == 'MP_')
 
+!phybusinit:
+   ! Compute linoz diags only on demand
+   out_linoz = .false.
+   out_linoz = (out_linoz .and. fluvert /= 'SURFACE')
+
+   llinozage = .false. !(llinoz .and. age_linoz)              ! age of air tracer off 
+   llinozout = (llinoz .and. out_linoz)
+   llinghout = (llingh .and. out_linoz)
+   lmoyhroz =(lmoyhr .and. llinoz .and. out_linoz)
+   lmoyhrgh =(lmoyhr .and. llingh .and. out_linoz)
+
    ltrigtau = (kfctrigtau > 0.)
    ltrigtauw = (deep_wavg .or. mid_wavg)
 

--- a/compile_mesh_sps.sh
+++ b/compile_mesh_sps.sh
@@ -38,7 +38,7 @@ cd sps
 if [ "$system" = "Science" ]; then
     git clone --no-checkout git@gitlab.science.gc.ca:continental-surface-hydrology/sps-dev.git .
 elif [ "$system" = "Other" ] || [ "$system" = "GPSCC"  ]; then	
-    git clone --branch 6.3 git@github.com:VVionnet/sps_dev.git .
+    git clone --branch 6.3 https://github.com/VVionnet/sps_dev.git .
 else
     echo "$system is an unvalid machine name. Please choose among: 'Scicence', 'GPSCC' and 'Other'"	
     exit
@@ -58,7 +58,7 @@ fi
 cd ../sps_build
 
 # Compile rpn physics
-cmake ../sps
+cmake --debug-trycompile ../sps
 make rpnphy -j4
 
 # Compile MESH

--- a/makefile
+++ b/makefile
@@ -255,13 +255,13 @@ endif
 # ======================================================================
 # General rules.
 %.o: %.f
-	$(FC) $(LFLAG) $(FFLAG) $(LIBNCO) $<
+	$(FC) $(LFLAG) $<
 %.o: %.F90
 	$(FC) $(LFLAG) $(FFLAG) $(INC_DIRS) $(DFLAG) $(LIBNCO) $<
 %.o: %.f90
 	$(FC) $(LFLAG) $(FFLAG) $(LIBNCO) $<
 %.o: %.for
-	$(FC) $(LFLAG) $(FFLAG) $(LIBNCO) $<
+	$(FC) $(LFLAG) $<
 %.o: %.c
 	$(CC) $(LFLAG) $(CFLAG) $(INC_DIRS) $<
 
@@ -299,7 +299,11 @@ all: ${OBJECTS}
 	$(FC) $(OBJECTS) -o $(OUT) $(LLINK) $(LIBNCL) \
 	-L$(SPS_BUILD_DIR)/src/rpnphy/rpnphy -lrpnphy \
 	-L$(SPS_BUILD_DIR)/src/modelutils/modelutils -lmodelutils -lmodelutils_tmg_stubs \
-	-lrmn -ltdpack -lrpncomm -liomp5 -lpthread
+	-L$(SPS_BUILD_DIR)/src/rmn -lrmn \
+	-L$(SPS_BUILD_DIR)/src/rmn/App/src/lib -lApp \
+	-L$(SPS_BUILD_DIR)/src/tdpack -ltdpack \
+	-L$(SPS_BUILD_DIR)/src/rpncomm/src -lrpncomm \
+	-liomp5 -lpthread
 	$(CLEANUP)
 
 # ======================================================================


### PR DESCRIPTION
(1) Changed the path to the git repository for the 'Other' option to use `https` syntax which doesn't require an active git configuration (i.e., credentials; e.g., if just to download the code), and added the `--debug-trycompile` option to the `cmake` command to preserve intermediary files (e.g., necessary *.mod files to compile the SVS connector in MESH) using newer cmake versions (e.g., at least 4.3.1) in compile_mesh_sps.sh. This change doesn't seem to have any impact to `cmake` 3.30 on GPSC/science.
(2) Removed variables that add free-form flags for compiling *.f and *.for files, which cause compatibility issues with newer gfortran versions, and added paths for local versions of `rmn`, `tdpack` and `rpncomm` libraries (and dependencies) in makefile, for when these are compiled as part of the SPS package. This should make no difference for `GPSC` environment where those libraries are linked as part of the `.eccc_setup_intel` environment.

Note A: The reference to the `iomp5` and `pthread` libraries (required for Intel environment on GPSC) do not seem to cause any linking error while compiling using GNU/gfortran.
Note B: Removing the free-form options for compiling *.f and *.for files also removes the debug and precision options attached to `FFLAG`, potentially enabled by options in makefile. There likely aren't still *.for files still used, and remaining *.f files in MESH aren't connected to any of the SVS options or code. This change is also contained to compiling MESH, and doesn't have any impact to compiling SPS/rpnphy or its dependencies, which are compiled independently.