### PR TITLE
Add option for half-hourly output

### DIFF
--- a/Driver/MESH_Driver/read_parameters_csv.f90
+++ b/Driver/MESH_Driver/read_parameters_csv.f90
@@ -415,6 +415,14 @@ subroutine read_parameters_csv(shd, iun, fname, ierr)
                     call assign_line_args(svs_mesh%vs%lout_svs2_watbal, args(2), istat)
                 end if                
 
+            case (VN_SVS_LOUT_HALF_HOURLY)
+                if (.not. svs_mesh%PROCESS_ACTIVE) then
+                    istat = istat + radix(istat)**pstat%INACTIVE
+                else
+                    p = 1
+                    call assign_line_args(svs_mesh%vs%lout_half_hourly, args(2), istat)
+                end if
+
             case (VN_SVS_LSNOW_INTERCEPTION_SVS2)
                 if (.not. svs_mesh%PROCESS_ACTIVE .or. svs_mesh%vs%schmsol=='SVS' ) then
                     istat = istat + radix(istat)**pstat%INACTIVE

--- a/LSS_Model/SVS/runsvs_mesh.F90
+++ b/LSS_Model/SVS/runsvs_mesh.F90
@@ -145,6 +145,7 @@ module runsvs_mesh
     character(len = *), parameter, public :: VN_SVS_LOUT_SVS1_WATBAL = 'LOUT_SVS1_WATBAL ' ! For svs1 only 
     character(len = *), parameter, public :: VN_SVS_NPROFILE_DAY = 'NPROFILE_DAY' ! For svs2 only
     character(len = *), parameter, public :: VN_SVS_LOUT_SVS2_WATBAL = 'LOUT_SVS2_WATBAL ' ! For svs2 only
+    character(len = *), parameter, public :: VN_SVS_LOUT_HALF_HOURLY = 'LOUT_HALF_HOURLY'
     character(len = *), parameter, public :: VN_SVS_LSOIL_FREEZING_SVS1 = 'LSOIL_FREEZING_SVS1' ! For svs1 only
     character(len = *), parameter, public :: VN_SVS_LMACROPORES_SVS = 'LMACROPORES_SVS' ! For svs1 only
     character(len = *), parameter, public :: VN_SVS_LPHASE_CHANGE_EFF_SVS1 = 'LPHASE_CHANGE_EFF_SVS1' ! For svs1 only
@@ -286,6 +287,7 @@ module runsvs_mesh
         logical :: lout_snow_enbal = .false.
         logical :: lout_snow_vegh = .false.
         logical :: lout_svs2_watbal = .false.
+        logical :: lout_half_hourly = .false.
         logical :: lwrite_restart = .false.
         logical :: lforlit = .false.
         logical :: read_oc = .false.
@@ -2028,7 +2030,11 @@ ierr = 200
 
 
            !if (ic%now%hour /= ic%next%hour) then !last time-step of hour
-           if (ic%now%mins ==0) then! Full hour
+           if (( &
+             svs_mesh%vs%lout_half_hourly .and. ic%now%mins == 30 &
+           ) .or. ( &
+             ic%now%mins == 0 & ! Full hour
+           )) then
 
               k=1 !>  Identity of the tile (offset relative to node-indexing).
 


### PR DESCRIPTION
This is a bit of a hack to get the benchcab analysis working with SVS. The analysis requires the model output frequency to be the same as the frequency as the driving data, and currently the driving data for the flux towers used are either at hourly or half-hourly, causing the half-hourly case to fail. This change adds an optional flag to MESH_parameters.txt to enable half-hourly output from SVS.